### PR TITLE
Production-mode builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,7 +46,27 @@ let
 
             exec node node_modules/parcel-bundler/bin/cli.js $FAKE_PKG/src/index.html --out-dir=$TMP_BASE/dist --cache-dir=$TMP_BASE/cache
           '';
-      in {
+
+        prodRunScript = pkgs.writeScript "run-web-frontend-prod"
+          ''
+            #!${pkgs.bash}/bin/bash
+            set -euo pipefail
+
+            cd "$(dirname "$(realpath "$0")")/.."
+
+            exec ${pkgs.darkhttpd}/bin/darkhttpd dist --port 1234
+          '';
+      in if prod
+        then {
+        extraBuildInputs = [ pkgs.utillinuxMinimal ];
+        installPhase =
+          ''
+            node node_modules/parcel-bundler/bin/cli.js build src/index.html --out-dir=$out/dist
+            mkdir -p $out/bin
+            cp ${prodRunScript} $out/bin/web-frontend
+          '';
+        }
+        else {
         extraBuildInputs = [ pkgs.makeWrapper ];
         postInstall =
           ''

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,6 @@
 {
   useDocker ? false,
+  prod ? false,
   pkgsOpts ?
     if useDocker
       then { system = "x86_64-linux"; }
@@ -62,7 +63,7 @@ let
     path = workspace."${name}";
   }) packages;
   dockerBuild = pkgs.callPackage ./docker.nix {
-    inherit packages workspace;
+    inherit packages workspace prod;
     inherit (pkgs.nodePackages) nodemon;
   };
 in

--- a/docker.nix
+++ b/docker.nix
@@ -2,6 +2,9 @@
   # Photo garden packages
   workspace, packages,
 
+  # Config
+  prod,
+
   # Dependencies
   lib,
   dockerTools,
@@ -65,7 +68,7 @@ in rec {
         };
         nodemonConfigJSON = writeText "nodemon.json" (builtins.toJSON nodemonConfig);
       in {
-        Cmd = if pkg.useNodemon or true
+        Cmd = if (!prod) && (pkg.useNodemon or true)
           then [ "${nodemon}/bin/nodemon" "--exec" "${nodejs}/bin/node" "--config" nodemonConfigJSON pkgBin ]
           else [ pkgBin ];
         Env = [
@@ -89,7 +92,7 @@ in rec {
         let
           existing = ((composeFileBase.services or {}).${name} or {}).volumes or [];
           dependencyVolumes = map (dep: "./${relativizePath ./. dep.src}:/node_modules/${dep.pname}") (pkgAndDeps workspace.${name});
-        in existing ++ dependencyVolumes;
+        in existing ++ lib.optionals (!prod) dependencyVolumes;
       };
     }) packages);
   };


### PR DESCRIPTION
This depends on #48.

This adds support for production-mode builds (by running `./docker-build.sh --arg prod true`), which don't contain all the tools used for development. Right now, this means that:

- [X] source code volumes are disabled
- [X] nodemon is disabled
- [X] web-frontend is AOT-compiled